### PR TITLE
add missing stdlib headers && set global variables in LKH to external for compile linking error

### DIFF
--- a/lib/LKH/Genetic.c
+++ b/lib/LKH/Genetic.c
@@ -2,6 +2,18 @@
 #include "Genetic.h"
 
 /*
+ * external global variables initialization
+ * values will be overwritten on runtime
+*/
+int PopulationSize = 0;
+int MaxPopulationSize = 0;
+CrossoverFunction Crossover = NULL;
+int **Population = NULL;
+GainType *PenaltyFitness = NULL;
+GainType *Fitness = NULL;
+
+
+/*
  * The AddToPopulation function adds the current tour as an individual to 
  * the population. The fitness of the individual is set equal to the cost
  * of the tour. The population is kept sorted in increasing fitness order.

--- a/lib/LKH/Genetic.h
+++ b/lib/LKH/Genetic.h
@@ -15,22 +15,22 @@
 
 typedef void (*CrossoverFunction) ();
 
-int MaxPopulationSize; /* The maximum size of the population */ 
-int PopulationSize;    /* The current size of the population */
+extern int MaxPopulationSize; /* The maximum size of the population */ 
+extern int PopulationSize;    /* The current size of the population */
 
-CrossoverFunction Crossover;
+extern CrossoverFunction Crossover;
 
-int **Population;      /* Array of individuals (solution tours) */
-GainType *PenaltyFitness;  /* The f itnesslty  (tour penalty) of each
-i                             individual */
-GainType *Fitness;     /* The fitness (tour cost) of each individual */
+extern int **Population;      /* Array of individuals (solution tours) */
+extern GainType *PenaltyFitness;  /* The f itnesslty  (tour penalty) of each
+i                                    individual */
+extern GainType *Fitness;     /* The fitness (tour cost) of each individual */
 
 void AddToPopulation(GainType Penalty, GainType Cost);
 void ApplyCrossover(int i, int j);
 void FreePopulation();
 int HasFitness(GainType Penalty, GainType Cost);
 int LinearSelection(int Size, double Bias);
-GainType MergeTourWithIndividual(int i);
+extern GainType MergeTourWithIndividual(int i);
 void PrintPopulation();
 void ReplaceIndividualWithTour(int i, GainType Penalty, GainType Cost);
 int ReplacementIndividual(GainType Penalty, GainType Cost);

--- a/lib/LKH/LKH.c
+++ b/lib/LKH/LKH.c
@@ -1,5 +1,11 @@
 #include "LKH.h"
 
+/*
+ * external global variables initialization
+ * values will be overwritten on runtime
+*/
+MergeTourFunction MergeWithTour = NULL;
+
 /* All global variables of the problem. */
 
 int AscentCandidates;   /* Number of candidate edges to be associated

--- a/lib/LKH/LKH.h
+++ b/lib/LKH/LKH.h
@@ -75,7 +75,7 @@ typedef Node *(*MoveFunction) (Node * t1, Node * t2, GainType * G0,
 typedef int (*CostFunction) (Node * Na, Node * Nb);
 typedef GainType (*PenaltyFunction) (void);
 typedef GainType (*MergeTourFunction) (void);
-MergeTourFunction MergeWithTour;
+extern MergeTourFunction MergeWithTour;
 
 /* B&B variable*/
 extern pthread_mutex_t Sol_lock;

--- a/lib/LKH/Sequence.c
+++ b/lib/LKH/Sequence.c
@@ -2,6 +2,20 @@
 #include "Segment.h"
 
 /*
+ * external global variables initialization
+ * values will be overwritten on runtime
+*/
+Node **t = NULL;
+Node **T = NULL;
+Node **tSaved = NULL;
+int *p = NULL;
+int *q = NULL;
+int *incl = NULL;
+int *cycle = NULL;
+GainType *G = NULL;
+int K = 0;
+
+/*
  * This file contains the functions FindPermutation and FeasibleKOptMove.
  */
 

--- a/lib/LKH/Sequence.h
+++ b/lib/LKH/Sequence.h
@@ -10,16 +10,16 @@
 
 #include "LKH.h"
 
-Node **t;       /* The sequence of nodes to be used in a move */
-Node **T;       /* The currently best t's */
-Node **tSaved;  /* For saving t when using the BacktrackKOptMove function */
-int *p;         /* The permutation corresponding to the sequence in which
-                   the t's occur on the tour */
-int *q;         /* The inverse permutation of p */
-int *incl;      /* Array: incl[i] == j, if (t[i], t[j]) is an inclusion edge */
-int *cycle;     /* Array: cycle[i] is cycle number of t[i] */
-GainType *G;    /* For storing the G-values in the BestKOptMove function */
-int K;          /* The value K for the current K-opt move */
+extern Node **t;       /* The sequence of nodes to be used in a move */
+extern Node **T;       /* The currently best t's */
+extern Node **tSaved;  /* For saving t when using the BacktrackKOptMove function */
+extern int *p;         /* The permutation corresponding to the sequence in which
+                          the t's occur on the tour */
+extern int *q;         /* The inverse permutation of p */
+extern int *incl;      /* Array: incl[i] == j, if (t[i], t[j]) is an inclusion edge */
+extern int *cycle;     /* Array: cycle[i] is cycle number of t[i] */
+extern GainType *G;    /* For storing the G-values in the BestKOptMove function */
+extern int K;          /* The value K for the current K-opt move */
 
 int FeasibleKOptMove(int k);
 void FindPermutation(int k);

--- a/lib/LKH/gpx.c
+++ b/lib/LKH/gpx.c
@@ -11,6 +11,18 @@
 #include "LKH.h"
 #include "gpx.h"
 
+/*
+ * external global variables initialization
+ * values will be overwritten on runtime
+*/
+int n_cities = 0, n_cand = 0;
+int n_partitions_size2 = 0, n_partitions_before_fusion = 0,
+n_partitions_after_fusion1 = 0, n_partitions_after_fusion2 = 0,
+n_partitions_after_fusion3 = 0;
+int n_partitions_after_fusion4 = 0, n_partitions_after_fusion5 = 0,
+n_partitions_after_fusionB = 0;
+Node **Map2Node = NULL;
+
 // GPX2
 GainType gpx(int *solution_blue, int *solution_red, int *offspring)
 {

--- a/lib/LKH/gpx.h
+++ b/lib/LKH/gpx.h
@@ -52,13 +52,13 @@ void fusionB_v2(int *sol_blue, int *sol_red);
 GainType off_gen(int *sol_blue, int *sol_red, int *offspring,
                  int *label_list);
 
-int n_cities, n_cand;
-int n_partitions_size2, n_partitions_before_fusion,
+extern int n_cities, n_cand;
+extern int n_partitions_size2, n_partitions_before_fusion,
 n_partitions_after_fusion1, n_partitions_after_fusion2,
 n_partitions_after_fusion3;
-int n_partitions_after_fusion4, n_partitions_after_fusion5,
+extern int n_partitions_after_fusion4, n_partitions_after_fusion5,
 n_partitions_after_fusionB;
-Node **Map2Node;
+extern Node **Map2Node;
 
 int *alloc_vectori(int lines);
 int **alloc_matrixi(int lines, int collums);

--- a/lib/history_table.hpp
+++ b/lib/history_table.hpp
@@ -2,6 +2,7 @@
 #define HASH_H
 
 #include <iostream>
+#include <list>
 
 #include <sys/sysinfo.h>
 

--- a/lib/timer.hpp
+++ b/lib/timer.hpp
@@ -2,6 +2,7 @@
 #define TIMER_H
 #include <unordered_map>
 #include <chrono>
+#include <string>
 
 class timer
 {


### PR DESCRIPTION
New compile resulted in linking issues. Following changes fixed the resulting errors:

added stdlib "list" to history_table.hpp
added stdlib "string" to timer.hpp

changed the global variables in LKH used in the in-house library to "extern" and initialized in respective implementation files.
added to:
Genetic.h/.c
gpx.h/.c
LKH.h/.c
Sequence.h/.c